### PR TITLE
(chore): Initial docker container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "ROS2 Development Container",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools"
+  ],
+  "postCreateCommand": "bash -c 'source /opt/ros/humble/setup.bash && colcon build'",
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/ros2_ws,type=bind,consistency=cached"
+  ],
+  "workspaceFolder": "/ros2_ws"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Base image: ROS 2 Humble Desktop Full
+FROM osrf/ros:humble-desktop
+
+# Install necessary development tools and dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    clang-format \
+    cmake \
+    git \
+    wget \
+    libssl-dev \
+    libpython3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a workspace
+ENV ROS_WS=/ros2_ws
+RUN mkdir -p $ROS_WS/src
+WORKDIR $ROS_WS
+
+# Source ROS 2 environment
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
+
+# Entry point
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # robot_solution_1
 Sandbox for create a simple robot solution.
+
+# Getting Started
+Repository: https://github.com/ddh20/robot_solution_1
+Building the Docker Container: `docker build --no-cache --platform linux/amd64 -t ros2-dev .`


### PR DESCRIPTION
Issue: 1

Why:
Provide a docker container that developers can use on their laptops so they don't have to install ROS2 and associated dependencies on them.

How:
Two files have been created, the Dockerfile which is used to create the container, and a devcontainer file that can be used in vscode to start the container.

The following is currently being used to build the container locally.

`docker build --no-cache --platform linux/amd64 -t ros2-dev .`

Risks:
None at this point

References:
I did use Google AI to create the Dockerfile initially.  Then added clang-format after.